### PR TITLE
Fix id fields not updated after previous renaming.

### DIFF
--- a/json/schema/configuration.json
+++ b/json/schema/configuration.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://vamp-plugins.org/piper/json/schema/pluginconfiguration#",
+    "id": "http://vamp-plugins.org/piper/json/schema/configuration#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "schema for a bundle of configuration data capturing the setup of a feature extractor",
     "type": "object",

--- a/json/schema/extractorstaticdata.json
+++ b/json/schema/extractorstaticdata.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://vamp-plugins.org/piper/json/schema/pluginstaticdata#",
+    "id": "http://vamp-plugins.org/piper/json/schema/extractorstaticdata#",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "schema for the static metadata associated with a feature extractor",
     "type": "object",


### PR DESCRIPTION
I noticed these when updating the schema files in piper-js, as they were causing tests which should've failed not to (the tv4 library apparently returns true when validating against schema for which it cannot find the refs). 